### PR TITLE
Use Optional in ProductRepo and update related methods

### DIFF
--- a/src/main/java/ProductRepo.java
+++ b/src/main/java/ProductRepo.java
@@ -1,5 +1,6 @@
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class ProductRepo {
     private List<Product> products;
@@ -13,13 +14,13 @@ public class ProductRepo {
         return products;
     }
 
-    public Product getProductById(String id) {
+    public Optional<Product> getProductById(String id) {
         for (Product product : products) {
             if (product.id().equals(id)) {
-                return product;
+                return Optional.of(product);
             }
         }
-        return null;
+        return Optional.empty();
     }
 
     public Product addProduct(Product newProduct) {

--- a/src/main/java/ShopService.java
+++ b/src/main/java/ShopService.java
@@ -1,5 +1,6 @@
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public class ShopService {
@@ -9,12 +10,12 @@ public class ShopService {
     public Order addOrder(List<String> productIds) {
         List<Product> products = new ArrayList<>();
         for (String productId : productIds) {
-            Product productToOrder = productRepo.getProductById(productId);
-            if (productToOrder == null) {
+            Optional<Product> productToOrder = productRepo.getProductById(productId);
+            if (productToOrder.isEmpty()) {
                 System.out.println("Product mit der Id: " + productId + " konnte nicht bestellt werden!");
                 return null;
             }
-            products.add(productToOrder);
+            products.add(productToOrder.get());
         }
 
         Order newOrder = new Order(UUID.randomUUID().toString(), products, OrderStatus.PROCESSING);

--- a/src/test/java/ProductRepoTest.java
+++ b/src/test/java/ProductRepoTest.java
@@ -1,7 +1,4 @@
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -27,11 +24,24 @@ class ProductRepoTest {
         ProductRepo repo = new ProductRepo();
 
         //WHEN
-        Product actual = repo.getProductById("1");
+        Optional<Product> actualOptional = repo.getProductById("1");
 
         //THEN
+        assertFalse(actualOptional.isEmpty());
         Product expected = new Product("1", "Apfel");
-        assertEquals(actual, expected);
+        assertEquals(actualOptional.get(), expected);
+    }
+
+    @org.junit.jupiter.api.Test
+    void getProductById_whenInvalidId_expectEmptyOptional() {
+        //GIVEN
+        ProductRepo repo = new ProductRepo();
+
+        //WHEN
+        Optional<Product> actualOptional = repo.getProductById("2");
+
+        //THEN
+        assertTrue(actualOptional.isEmpty());
     }
 
     @org.junit.jupiter.api.Test
@@ -46,7 +56,7 @@ class ProductRepoTest {
         //THEN
         Product expected = new Product("2", "Banane");
         assertEquals(actual, expected);
-        assertEquals(repo.getProductById("2"), expected);
+        assertEquals(repo.getProductById("2").orElse(null), expected);
     }
 
     @org.junit.jupiter.api.Test
@@ -58,6 +68,6 @@ class ProductRepoTest {
         repo.removeProduct("1");
 
         //THEN
-        assertNull(repo.getProductById("1"));
+        assertTrue(repo.getProductById("1").isEmpty());
     }
 }


### PR DESCRIPTION
Replaced nullable returns with `Optional` in `getProductById` for better null safety. Updated all related code in `ShopService`, tests, and assertions to handle `Optional` appropriately. Added a new test case to validate behavior with invalid product IDs.